### PR TITLE
Enable the filtering of images

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@types/express": "^4.17.0",
     "@types/node": "^11.13.17",
+    "@types/validator": "^13.6.3",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
     "eslint": "^7.32.0",
@@ -33,6 +34,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "jimp": "^0.16.1",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "validator": "^13.6.0"
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,4 @@
-import express from "express"
-import bodyParser from "body-parser"
+import express, {json as parseJsonBody} from "express"
 
 import {deleteLocalFiles, filterImageFromURL} from "./util/util";
 
@@ -11,8 +10,7 @@ import {deleteLocalFiles, filterImageFromURL} from "./util/util";
   // Set the network port
   const port = process.env.PORT || 8082
 
-  // Use the body parser middleware for post requests
-  app.use(bodyParser.json())
+  app.use(parseJsonBody())
 
   // @TODO1 IMPLEMENT A RESTFUL ENDPOINT
   // GET /filteredimage?image_url={{URL}}

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,8 +22,6 @@ import {deleteLocalFiles, filterImageFromURL, validateURL} from "./util/util";
         .send("Error: image URL must be a string.")
     }
 
-    // TODO: try turning off this URL validation and see what filterImageFromURL() does
-    // when given an invalid URL or a URL to an image that can't be accessed for some reason.
     const isImageURLValid = validateURL(imageURL)
     if (!isImageURLValid) {
       return res
@@ -43,7 +41,7 @@ import {deleteLocalFiles, filterImageFromURL, validateURL} from "./util/util";
 
     res.sendFile(pathToFilteredImage, (err) => {
       if (err) {
-        console.error("Failed to send filtered image because of this error:", err)
+        console.error("Failed to send filtered image to client because of this error:", err)
       }
 
       deleteLocalFiles([pathToFilteredImage])

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,42 +1,59 @@
 import express, {json as parseJsonBody} from "express"
 
-import {deleteLocalFiles, filterImageFromURL} from "./util/util";
+import {deleteLocalFiles, filterImageFromURL, validateURL} from "./util/util";
 
-(async () => {
-
-  // Init the Express application
+(() => {
   const app = express()
 
-  // Set the network port
   const port = process.env.PORT || 8082
 
   app.use(parseJsonBody())
 
-  // @TODO1 IMPLEMENT A RESTFUL ENDPOINT
-  // GET /filteredimage?image_url={{URL}}
-  // endpoint to filter an image from a public url.
-  // IT SHOULD
-  //    1
-  //    1. validate the image_url query
-  //    2. call filterImageFromURL(image_url) to filter the image
-  //    3. send the resulting file in the response
-  //    4. deletes any files on the server on finish of the response
-  // QUERY PARAMATERS
-  //    image_url: URL of a publicly accessible image
-  // RETURNS
-  //   the filtered image file [!!TIP res.sendFile(filteredpath); might be useful]
+  app.get("/filteredimage", async (req, res) => {
+    const {image_url: imageURL} = req.query
+    if (!imageURL) {
+      return res
+        .status(400)
+        .send("Error: an image URL was not supplied.")
+    }
+    if (typeof imageURL !== "string") {
+      return res
+        .status(400)
+        .send("Error: image URL must be a string.")
+    }
 
-  /**************************************************************************** */
+    // TODO: try turning off this URL validation and see what filterImageFromURL() does
+    // when given an invalid URL or a URL to an image that can't be accessed for some reason.
+    const isImageURLValid = validateURL(imageURL)
+    if (!isImageURLValid) {
+      return res
+        .status(400)
+        .send("Error: the image URL supplied is not a valid URL.")
+    }
 
-  //! END @TODO1
+    let pathToFilteredImage: string
+    try {
+      pathToFilteredImage = await filterImageFromURL(imageURL)
+    } catch (err) {
+      console.error("Failed to filter image because of this error:", err)
+      return res
+        .status(500)
+        .send("There was a problem fetching your image. Please check the URL and try again.")
+    }
 
-  // Root Endpoint
-  // Displays a simple message to the user
-  app.get("/", (req, res) => {
-    res.send("try GET /filteredimage?image_url={{}}")
+    res.sendFile(pathToFilteredImage, (err) => {
+      if (err) {
+        console.error("Failed to send filtered image because of this error:", err)
+      }
+
+      deleteLocalFiles([pathToFilteredImage])
+    })
   })
 
-  // Start the Server
+  app.get("/", (req, res) => {
+    res.send("This is the root route and it doesn't do much. Instead, try sending a request as: GET /filteredimage?image_url=SOME_URL")
+  })
+
   app.listen(port, () => {
     // eslint-disable-next-line no-console
     console.log(`Server running at http://localhost:${port}`)

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,7 +38,7 @@ import {deleteLocalFiles, filterImageFromURL, validateURL} from "./util/util";
       console.error("Failed to filter image because of this error:", err)
       return res
         .status(500)
-        .send("There was a problem fetching your image. Please check the URL and try again.")
+        .send("The image at the given URL isn't accessible. Please check the URL and try again.")
     }
 
     res.sendFile(pathToFilteredImage, (err) => {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,5 +1,6 @@
+import Jimp from "jimp"
 import fs from "fs"
-import jimp from "jimp"
+import isURL from "validator/lib/isURL"
 
 // filterImageFromURL
 // helper function to download, filter, and save the filtered image locally
@@ -8,16 +9,23 @@ import jimp from "jimp"
 //    inputURL: string - a publicly accessible url to an image file
 // RETURNS
 //    an absolute path to a filtered image locally saved file
-export async function filterImageFromURL(inputURL: string): Promise<string>{
-  return new Promise(async (resolve) => {
-    const photo = await jimp.read(inputURL)
-    const outpath = "/tmp/filtered."+Math.floor(Math.random() * 2000)+".jpg"
-    await photo
-      .resize(256, 256) // resize
-      .quality(60) // set JPEG quality
-      .greyscale() // set greyscale
-      .write(__dirname+outpath, (img) => {
-        resolve(__dirname+outpath)
+export async function filterImageFromURL(inputURL: string): Promise<string> {
+  let photo: Jimp
+  try {
+    photo = await Jimp.read(inputURL)
+  } catch (err) {
+    console.error("Failed to read image because of the following error:", err)
+    return Promise.reject(err)
+  }
+  const outpath = `filtered.${Math.floor(Math.random() * 2000)}.jpg`
+
+  return new Promise((resolve) => {
+    photo
+      .resize(256, 256)
+      .quality(60)
+      .greyscale()
+      .write(`${__dirname}${outpath}`, () => {
+        resolve(`${__dirname}${outpath}`)
       })
   })
 }
@@ -27,8 +35,31 @@ export async function filterImageFromURL(inputURL: string): Promise<string>{
 // useful to cleanup after tasks
 // INPUTS
 //    files: Array<string> an array of absolute paths to files
-export async function deleteLocalFiles(files:Array<string>) {
+export function deleteLocalFiles(files:Array<string>): void {
   for (const file of files) {
     fs.unlinkSync(file)
   }
+}
+
+/**
+ * @name validateURL
+ * @description Tests a string to confirm whether or not it's a valid URL.
+ * @param {string} url - the string to test.
+ * @returns {boolean} - returns true if the string is a valid URL. Returns
+ * false if it isn't.
+ */
+export const validateURL = (url: string): boolean => {
+  // I thought of getting a failsafe regex from Stackoverflow but most of the top
+  // answers are over 3 years old and are probably not regularly updated by their
+  // authors. So I decided to install a well-maintained and popular dependency instead.
+  // And I decided to use validator.isURL() inside a function instead of calling it
+  // directly because I wanted to abstract away how I validate URLs. So tomorrow I
+  // could switch to using regex, but the function for validating URLs will remain the same.
+  return isURL(
+    url,
+    {
+      protocols: [ "http", "https" ],
+      allow_protocol_relative_urls: true,
+    }
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,11 @@
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
+"@types/validator@^13.6.3":
+  version "13.6.3"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.6.3.tgz#31ca2e997bf13a0fffca30a25747d5b9f7dbb7de"
+  integrity sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw==
+
 "@typescript-eslint/eslint-plugin@^4.30.0":
   version "4.30.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.30.0.tgz#4a0c1ae96b953f4e67435e20248d812bfa55e4fb"
@@ -2101,6 +2106,11 @@ v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
+validator@^13.6.0:
+  version "13.6.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.6.0.tgz#1e71899c14cdc7b2068463cb24c1cc16f6ec7059"
+  integrity sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR adds an endpoint that enables users to apply filters to images. The request signature is:
`GET /filteredimage?image_url=SOME_URL`
where `SOME_URL` is a valid URL for a publicly-accessible image.

The filter that is currently applied transforms the image to black-and-white, reduces its quality to 60% and its dimensions to 256x256.

Note that due to [this unresolved issue](https://github.com/oliver-moran/jimp/issues/643) some image URLs that can be viewed in a browser cannot be opened by [Jimp](https://www.npmjs.com/package/jimp). For such images, the endpoint returns a failure message.